### PR TITLE
Add tests and simplify plot_GMM function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,8 @@ Description: The main function, plot_GMM, is used for plotting output from Gauss
     Gaussian mixture models. For the plot_mix_comps function, usage most often will be specifying 
     the "fun" argument within "stat_function" in a ggplot2 object.
 Imports: ggplot2, mixtools, methods, graphics
+Suggests:
+    testthat
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/plot_GMM.R
+++ b/R/plot_GMM.R
@@ -1,22 +1,22 @@
-#'Plots Mixture Components from Gaussian Mixture Models
-#'
-#'Generates a plot of data densities with overlaid mixture components from a Gaussian mixture model (GMM)
-#'@usage plot_GMM(m, k=NULL)
-#'@param m An object of class \code{mixEM} corresponding with the fit GMM
-#'@param k The number of components specified in the GMM, \code{m}
-#'@details Uses ggplot2 graphics to plot data densities with overlaid components from \code{mixEM} objects, which are GMM's fit using the \code{mixtools} package.
-#'
-#'Note: Users must enter the same component value, \code{k}, in the \code{plot_GMM} function, as that which was specified in the original GMM specification (also \code{k} in \code{mixtools}).
-#'@examples
-#'set.seed(235)
-#'mixmdl <- mixtools::normalmixEM(faithful$waiting, k = 2)
-#'
-#'plot_GMM(mixmdl, 2)
-#'@references Benaglia, T., Chauveau, D., Hunter, D. and Young, D., 2009. mixtools: An R package for analyzing finite mixture models. Journal of Statistical Software, 32(6), pp.1-29.
-#'
-#'Wickham, H., 2016. ggplot2: elegant graphics for data analysis. Springer.
-#'
-#'@export
+#' Plots Mixture Components from Gaussian Mixture Models
+#' 
+#' Generates a plot of data densities with overlaid mixture components from a Gaussian mixture model (GMM)
+#' @usage plot_GMM(m, k=NULL)
+#' @param m An object of class \code{mixEM} corresponding with the fit GMM
+#' @param k The number of components specified in the GMM, \code{m}
+#' @details Uses ggplot2 graphics to plot data densities with overlaid components from \code{mixEM} objects, which are GMM's fit using the \code{mixtools} package.
+#' 
+#' Note: Users must enter the same component value, \code{k}, in the \code{plot_GMM} function, as that which was specified in the original GMM specification (also \code{k} in \code{mixtools}).
+#' @examples
+#' set.seed(235)
+#' mixmdl <- mixtools::normalmixEM(faithful$waiting, k = 2)
+#' 
+#' plot_GMM(mixmdl, 2)
+#' @references Benaglia, T., Chauveau, D., Hunter, D. and Young, D., 2009. mixtools: An R package for analyzing finite mixture models. Journal of Statistical Software, 32(6), pp.1-29.
+#' 
+#' Wickham, H., 2016. ggplot2: elegant graphics for data analysis. Springer.
+#' 
+#' @export
 
 plot_GMM <- function(m, k=NULL) {
   if (!requireNamespace("ggplot2", quietly = TRUE)) {
@@ -39,449 +39,46 @@ plot_GMM <- function(m, k=NULL) {
   x <- data.frame(x)
   if (k <= 1){
     stop("Specified components must be at least length 2.")
-  }
-  if (k == 2){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 3){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 4){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 5){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 6){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 7){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 8){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 9){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[9], m$sigma[9], lam = m$lambda[9]),
-                             colour = "dodgerblue", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 10){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[9], m$sigma[9], lam = m$lambda[9]),
-                             colour = "dodgerblue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[10], m$sigma[10], lam = m$lambda[10]),
-                             colour = "darkorange3", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 11){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[9], m$sigma[9], lam = m$lambda[9]),
-                             colour = "dodgerblue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[10], m$sigma[10], lam = m$lambda[10]),
-                             colour = "darkorange3", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[11], m$sigma[11], lam = m$lambda[11]),
-                             colour = "burlywood4", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 12){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[9], m$sigma[9], lam = m$lambda[9]),
-                             colour = "dodgerblue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[10], m$sigma[10], lam = m$lambda[10]),
-                             colour = "darkorange3", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[11], m$sigma[11], lam = m$lambda[11]),
-                             colour = "burlywood4", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[12], m$sigma[12], lam = m$lambda[12]),
-                             colour = "darkmagenta", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 13){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[9], m$sigma[9], lam = m$lambda[9]),
-                             colour = "dodgerblue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[10], m$sigma[10], lam = m$lambda[10]),
-                             colour = "darkorange3", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[11], m$sigma[11], lam = m$lambda[11]),
-                             colour = "burlywood4", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[12], m$sigma[12], lam = m$lambda[12]),
-                             colour = "darkmagenta", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[13], m$sigma[13], lam = m$lambda[13]),
-                             colour = "firebrick", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 14){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[9], m$sigma[9], lam = m$lambda[9]),
-                             colour = "dodgerblue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[10], m$sigma[10], lam = m$lambda[10]),
-                             colour = "darkorange3", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[11], m$sigma[11], lam = m$lambda[11]),
-                             colour = "burlywood4", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[12], m$sigma[12], lam = m$lambda[12]),
-                             colour = "darkmagenta", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[13], m$sigma[13], lam = m$lambda[13]),
-                             colour = "firebrick", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[14], m$sigma[14], lam = m$lambda[14]),
-                             colour = "deeppink2", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k == 15){
-    ggplot2::ggplot(data.frame(x)) +
-      ggplot2::geom_histogram(ggplot2::aes(x, ..density..), binwidth = 1, colour = "darkgray", fill = "lightgray") +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[1], m$sigma[1], lam = m$lambda[1]),
-                             colour = "red", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[2], m$sigma[2], lam = m$lambda[2]),
-                             colour = "blue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[3], m$sigma[3], lam = m$lambda[3]),
-                             colour = "green", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[4], m$sigma[4], lam = m$lambda[4]),
-                             colour = "yellow", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[5], m$sigma[5], lam = m$lambda[5]),
-                             colour = "orange", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[6], m$sigma[6], lam = m$lambda[6]),
-                             colour = "purple", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[7], m$sigma[7], lam = m$lambda[7]),
-                             colour = "darksalmon", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[8], m$sigma[8], lam = m$lambda[8]),
-                             colour = "goldenrod2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[9], m$sigma[9], lam = m$lambda[9]),
-                             colour = "dodgerblue", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[10], m$sigma[10], lam = m$lambda[10]),
-                             colour = "darkorange3", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[11], m$sigma[11], lam = m$lambda[11]),
-                             colour = "burlywood4", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[12], m$sigma[12], lam = m$lambda[12]),
-                             colour = "darkmagenta", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[13], m$sigma[13], lam = m$lambda[13]),
-                             colour = "firebrick", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[14], m$sigma[14], lam = m$lambda[14]),
-                             colour = "deeppink2", lwd = 1) +
-      ggplot2::stat_function(geom = "line", fun = plotGMM::plot_mix_comps,
-                             args = list(m$mu[15], m$sigma[15], lam = m$lambda[15]),
-                             colour = "darkseagreen1", lwd = 1) +
-      ggplot2::ylab("Density") +
-      ggplot2::theme_bw()
-  }
-  else if (k >= 16){
+  } else if (k >= 16){
     stop("Are you really searching for 16 or more clusters? If so, open an issue ticket: `https://github.com/pdwaggoner/plotGMM/issues`\nand we will consider updating the package. If not, go back and make sure the GMM is properly specified.")
   }
+
+  component_colors <-
+    c(
+      "red",
+      "blue",
+      "green",
+      "yellow",
+      "orange",
+      "purple",
+      "darksalmon",
+      "goldenrod2",
+      "dodgerblue", 
+      "darkorange3",
+      "burlywood4", 
+      "darkmagenta", 
+      "firebrick",
+      "deeppink2",
+      "darkseagreen1"
+    )
+
+  out_plot <- 
+    ggplot2::ggplot(data.frame(x)) +
+    ggplot2::geom_histogram(
+      ggplot2::aes(x, ..density..), 
+      binwidth = 1, colour = "darkgray", fill = "lightgray"
+    )
+
+  for (i in seq(1, k)) {
+    out_plot <- 
+      out_plot + 
+      ggplot2::stat_function(geom = "line", fun = plot_mix_comps,
+                           args = list(m$mu[i], m$sigma[i], lam = m$lambda[i]),
+                           colour = component_colors[i], lwd = 1) +
+      ggplot2::ylab("Density") +
+      ggplot2::theme_bw()
+  }
+
+  out_plot
+  
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library("testthat")
+library("plotGMM")
+
+test_check("plotGMM")

--- a/tests/testthat/test_plot_GMM.R
+++ b/tests/testthat/test_plot_GMM.R
@@ -1,0 +1,20 @@
+context("plot_GMM")
+
+set.seed(235)
+
+test_that("plot_GMM catches input errors", {
+  mixmdl <- mixtools::normalmixEM(faithful$waiting, k = 2)
+  expect_error(plot_GMM(mixmdl, k = 1))
+  expect_error(plot_GMM(mixmdl, k = 16))
+})
+
+# Testing beyond 11 components causes problems.
+test_that("plot_GMM successfully plots", {
+  for (num_comps in seq(2, 11)) {
+    mixmdl <- mixtools::normalmixEM(faithful$waiting, k = num_comps)
+    expect_is(plot_GMM(mixmdl, k = num_comps), "ggplot")
+  }
+})
+
+
+


### PR DESCRIPTION
This pull requests adds unit tests and simplifies the `plot_GMM` function:

* `R/plot_GMM.R`: Uses a for loop now to add `stat_function` layers.
* `DESCRIPTION`: Add `testthat` as a suggested package.
* `tests/testthat.R`: Setup the unit test framework
* `tests/testthat/test_plot_GMM.R`: Adds unit tests for the `plot_GMM` package